### PR TITLE
Add Nullifier and IDs

### DIFF
--- a/circuits/venmo_receive.circom
+++ b/circuits/venmo_receive.circom
@@ -17,11 +17,9 @@ include "./regexes/venmo_timestamp.circom";
 // Max header bytes shouldn't need to be changed much per email,
 // but the max mody bytes may need to be changed to be larger if the email has a lot of i.e. HTML formatting
 // TODO: split into header and body
-template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, expose_from, expose_to) {
+template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
     assert(max_header_bytes % 64 == 0);
     assert(max_body_bytes % 64 == 0);
-    assert(expose_from < 2); // 1 if we should expose the from, 0 if we should not
-    assert(expose_to == 0); // 1 if we should expose the to, 0 if we should not: due to hotmail restrictions, we force-disable this
     assert(n * k > 1024); // constraints for 2048 bit RSA
     assert(n < (255 \ 2)); // we want a multiplication to fit into a circom signal
 
@@ -30,9 +28,6 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
     signal input signature[k]; // rsa signature. split up into k parts of n bits each.
     signal input in_len_padded_bytes; // length of in email data including the padding, which will inform the sha256 block length
 
-    // Identity commitment variables
-    // (note we don't need to constrain the + 1 due to https://geometry.xyz/notebook/groth16-malleability)
-    signal input address;
 
     // Base 64 body hash variables
     var LEN_SHA_B64 = 44;     // ceil(32 / 3) * 4, due to base64 encoding.
@@ -151,6 +146,7 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
     }
 
     // The following signals do not take part in any computation, but tie the proof to a specific order_id & claim_id to prevent replay attacks and frontrunning.
+    // https://geometry.xyz/notebook/groth16-malleability
     signal input order_id;
     signal input claim_id;
     signal order_id_squared;
@@ -168,6 +164,4 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
 // * n = 121 is the number of bits in each chunk of the modulus (RSA parameter)
 // * k = 9 is the number of chunks in the modulus (RSA parameter)
 // * pack_size = 7 is the number of bytes that can fit into a 255ish bit signal (can increase later)
-// * expose_from = 0 is whether to expose the from email address
-// * expose_to = 0 is whether to expose the to email (not recommended)
-component main { public [ modulus, address ] } = VenmoReceiveEmail(1024, 6400, 121, 9, 7, 0, 0);
+component main { public [ modulus, order_id, claim_id ] } = VenmoReceiveEmail(1024, 6400, 121, 9, 7);

--- a/circuits/venmo_receive.circom
+++ b/circuits/venmo_receive.circom
@@ -1,6 +1,7 @@
 pragma circom 2.1.5;
 
 include "../node_modules/circomlib/circuits/bitify.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
 include "./helpers/sha.circom";
 include "./helpers/rsa.circom";
 include "./helpers/base64.circom";
@@ -136,6 +137,15 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size) {
 
     // PACKING: 16,800 constraints (Total: [x])
     reveal_venmo_receive_packed <== ShiftAndPack(max_body_bytes, max_venmo_receive_len, pack_size)(venmo_receive_regex_reveal, venmo_receive_id_idx);
+
+    // Hash onramper ID
+    component hash = Poseidon(max_venmo_receive_packed_bytes);
+    assert(max_venmo_receive_packed_bytes < 16);
+    for (var i = 0; i < max_venmo_receive_packed_bytes; i++) {
+        hash.inputs[i] <== reveal_venmo_receive_packed[i];
+    }
+    signal output packed_onramper_id_hashed <== hash.out;
+    log("Hash of packed Venmo Onramper ID", packed_onramper_id_hashed);
 
 
     // Nullifier

--- a/circuits/venmo_receive.circom
+++ b/circuits/venmo_receive.circom
@@ -124,6 +124,7 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
     (timestamp_regex_out, timestamp_regex_reveal) <== VenmoTimestampRegex(max_header_bytes)(in_padded);
     timestamp_regex_out === 1;
 
+    // PACKING: 16,800 constraints (Total: [x])
     reveal_email_timestamp_packed <== ShiftAndPack(max_header_bytes, max_email_timestamp_len, pack_size)(timestamp_regex_reveal, email_timestamp_idx);
     
     
@@ -135,15 +136,19 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
     signal output reveal_venmo_receive_packed[max_venmo_receive_packed_bytes];
 
     signal (venmo_receive_regex_out, venmo_receive_regex_reveal[max_body_bytes]) <== VenmoReceiveId(max_body_bytes)(in_body_padded);
-    // This ensures we found a match at least once (i.e. match count is not zero)
     signal is_found_venmo_receive <== IsZero()(venmo_receive_regex_out);
     is_found_venmo_receive === 0;
 
     // PACKING: 16,800 constraints (Total: [x])
     reveal_venmo_receive_packed <== ShiftAndPack(max_body_bytes, max_venmo_receive_len, pack_size)(venmo_receive_regex_reveal, venmo_receive_id_idx);
 
-    // TODO: Nullifier
-    // TODO: Order ID
+
+    // Nullifier
+    // Packed SHA256 hash of the email header and body hash (the part that is signed upon)
+    signal output nullifier[msg_len];
+    for (var i = 0; i < msg_len; i++) {
+        nullifier[i] <== base_msg[i].out;
+    }
 }
 
 // In circom, all output signals of the main component are public (and cannot be made private), the input signals of the main component are private if not stated otherwise using the keyword public as above. The rest of signals are all private and cannot be made public.

--- a/circuits/venmo_receive.circom
+++ b/circuits/venmo_receive.circom
@@ -166,7 +166,7 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
 // * max_header_bytes = 1024 is the max number of bytes in the header
 // * max_body_bytes = 6400 is the max number of bytes in the body after precomputed slice
 // * n = 121 is the number of bits in each chunk of the modulus (RSA parameter)
-// * k = 17 is the number of chunks in the modulus (RSA parameter)
+// * k = 9 is the number of chunks in the modulus (RSA parameter)
 // * pack_size = 7 is the number of bytes that can fit into a 255ish bit signal (can increase later)
 // * expose_from = 0 is whether to expose the from email address
 // * expose_to = 0 is whether to expose the to email (not recommended)

--- a/circuits/venmo_receive.circom
+++ b/circuits/venmo_receive.circom
@@ -149,6 +149,14 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
     for (var i = 0; i < msg_len; i++) {
         nullifier[i] <== base_msg[i].out;
     }
+
+    // The following signals do not take part in any computation, but tie the proof to a specific order_id & claim_id to prevent replay attacks and frontrunning.
+    signal input order_id;
+    signal input claim_id;
+    signal order_id_squared;
+    signal claim_id_squared;
+    order_id_squared <== order_id * order_id;
+    claim_id_squared <== claim_id * claim_id;
 }
 
 // In circom, all output signals of the main component are public (and cannot be made private), the input signals of the main component are private if not stated otherwise using the keyword public as above. The rest of signals are all private and cannot be made public.

--- a/circuits/venmo_receive.circom
+++ b/circuits/venmo_receive.circom
@@ -22,7 +22,7 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
     assert(max_body_bytes % 64 == 0);
     assert(expose_from < 2); // 1 if we should expose the from, 0 if we should not
     assert(expose_to == 0); // 1 if we should expose the to, 0 if we should not: due to hotmail restrictions, we force-disable this
-    assert(n * k > 2048); // constraints for 2048 bit RSA
+    assert(n * k > 1024); // constraints for 2048 bit RSA
     assert(n < (255 \ 2)); // we want a multiplication to fit into a circom signal
 
     signal input in_padded[max_header_bytes]; // prehashed email data, includes up to 512 + 64? bytes of padding pre SHA256, and padded with lots of 0s at end after the length
@@ -157,4 +157,4 @@ template VenmoReceiveEmail(max_header_bytes, max_body_bytes, n, k, pack_size, ex
 // * pack_size = 7 is the number of bytes that can fit into a 255ish bit signal (can increase later)
 // * expose_from = 0 is whether to expose the from email address
 // * expose_to = 0 is whether to expose the to email (not recommended)
-component main { public [ modulus, address ] } = VenmoReceiveEmail(1024, 6400, 121, 17, 7, 0, 0);
+component main { public [ modulus, address ] } = VenmoReceiveEmail(1024, 6400, 121, 9, 7, 0, 0);

--- a/circuits/venmo_send.circom
+++ b/circuits/venmo_send.circom
@@ -140,7 +140,7 @@ template VenmoSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size, expos
     // PACKING: 16,800 constraints (Total: [x])
     reveal_venmo_send_packed <== ShiftAndPack(max_body_bytes, max_venmo_send_len, pack_size)(venmo_send_regex_reveal, venmo_send_id_idx);
 
-    // NULLIFIER
+    // Nullifier
     // Packed SHA256 hash of the email header and body hash (the part that is signed upon)
     signal output nullifier[msg_len];
     for (var i = 0; i < msg_len; i++) {
@@ -163,8 +163,8 @@ template VenmoSendEmail(max_header_bytes, max_body_bytes, n, k, pack_size, expos
 // * max_header_bytes = 1024 is the max number of bytes in the header
 // * max_body_bytes = 6400 is the max number of bytes in the body after precomputed slice
 // * n = 121 is the number of bits in each chunk of the modulus (RSA parameter)
-// * k = 17 is the number of chunks in the modulus (RSA parameter)
+// * k = 9 is the number of chunks in the modulus (RSA parameter)
 // * pack_size = 7 is the number of bytes that can fit into a 255ish bit signal (can increase later)
 // * expose_from = 0 is whether to expose the from email address
 // * expose_to = 0 is whether to expose the to email (not recommended)
-component main { public [ modulus, address ] } = VenmoSendEmail(1024, 5952, 121, 17, 7, 0, 0);
+component main { public [ modulus, address ] } = VenmoSendEmail(1024, 5952, 121, 9, 7, 0, 0);

--- a/src/scripts/generate_input.ts
+++ b/src/scripts/generate_input.ts
@@ -137,10 +137,10 @@ export async function getCircuitInputs(
   // Update preselector string based on circuit type
   if (circuit === CircuitType.EMAIL_VENMO_RECEIVE) {
     STRING_PRESELECTOR_FOR_EMAIL_TYPE = "\r\ntps://venmo.com/code?user_id=3D";
-    MAX_BODY_PADDED_BYTES_FOR_EMAIL_TYPE = 6400;
+    MAX_BODY_PADDED_BYTES_FOR_EMAIL_TYPE = 6400;  // 6200 length + 200 chars long custom message
   } else if (circuit === CircuitType.EMAIL_VENMO_SEND) {
     STRING_PRESELECTOR_FOR_EMAIL_TYPE = "                    href=3D\"https://venmo.com/code?user_id=3D";
-    MAX_BODY_PADDED_BYTES_FOR_EMAIL_TYPE = 6400;
+    MAX_BODY_PADDED_BYTES_FOR_EMAIL_TYPE = 6016;  // 5708 length + 300 chars long custom message
   }
 
   // Derive modulus from signature

--- a/src/scripts/generate_input.ts
+++ b/src/scripts/generate_input.ts
@@ -229,12 +229,11 @@ export async function getCircuitInputs(
       precomputed_sha,
       in_body_padded,
       in_body_len_padded_bytes,
-      venmo_receive_id_idx,
-      address,
-      // address_plus_one,
       body_hash_idx,
+      // venmo specific indices
       email_timestamp_idx,
-      // email_from_idx,
+      venmo_receive_id_idx,
+      // IDs
       order_id,
       claim_id
     };
@@ -253,12 +252,11 @@ export async function getCircuitInputs(
       precomputed_sha,
       in_body_padded,
       in_body_len_padded_bytes,
-      venmo_send_id_idx,
-      venmo_amount_idx,
-      address,
-      // address_plus_one,
       body_hash_idx,
-      // email_from_idx,
+      // venmo specific indices
+      venmo_amount_idx,
+      venmo_send_id_idx,
+      // IDs
       order_id,
       claim_id
     };

--- a/src/scripts/generate_input.ts
+++ b/src/scripts/generate_input.ts
@@ -52,6 +52,8 @@ export interface ICircuitInputs {
   email_timestamp_idx?: string;
   venmo_send_id_idx?: string;
   venmo_amount_idx?: string;
+  order_id?: string;
+  claim_id?: string;
 
   // subject commands only
   command_idx?: string;
@@ -116,6 +118,8 @@ export async function getCircuitInputs(
   message: Buffer,
   body: Buffer,
   body_hash: string,
+  order_id: string,
+  claim_id: string,
   eth_address: string,
   circuit: CircuitType
 ): Promise<{
@@ -129,7 +133,7 @@ export async function getCircuitInputs(
 
   let MAX_BODY_PADDED_BYTES_FOR_EMAIL_TYPE = MAX_BODY_PADDED_BYTES;
   let STRING_PRESELECTOR_FOR_EMAIL_TYPE = STRING_PRESELECTOR;
-  
+
   // Update preselector string based on circuit type
   if (circuit === CircuitType.EMAIL_VENMO_RECEIVE) {
     STRING_PRESELECTOR_FOR_EMAIL_TYPE = "\r\ntps://venmo.com/code?user_id=3D";
@@ -200,10 +204,10 @@ export async function getCircuitInputs(
 
   let raw_header = Buffer.from(prehash_message_string).toString();
   const email_from_idx = raw_header.length - trimStrByStr(trimStrByStr(raw_header, "from:"), "<").length;
-  
+
   let email_subject = trimStrByStr(raw_header, "\r\nsubject:");
   //in javascript, give me a function that extracts the first word in a string, everything before the first space
-  
+
   if (circuit === CircuitType.RSA) {
     circuitInputs = {
       modulus,
@@ -214,9 +218,9 @@ export async function getCircuitInputs(
     const RECEIVE_ID_SELECTOR = Buffer.from(STRING_PRESELECTOR_FOR_EMAIL_TYPE);
     const venmo_receive_id_idx = (Buffer.from(bodyRemaining).indexOf(RECEIVE_ID_SELECTOR) + RECEIVE_ID_SELECTOR.length).toString();
     const email_timestamp_idx = (raw_header.length - trimStrByStr(raw_header, "t=").length).toString();
-    
+
     console.log("Indexes into for venmo receive email are: ", email_timestamp_idx, venmo_receive_id_idx);
-    
+
     circuitInputs = {
       in_padded,
       modulus,
@@ -231,6 +235,8 @@ export async function getCircuitInputs(
       body_hash_idx,
       email_timestamp_idx,
       // email_from_idx,
+      order_id,
+      claim_id
     };
   } else if (circuit === CircuitType.EMAIL_VENMO_SEND) {
     const SEND_ID_SELECTOR = Buffer.from(STRING_PRESELECTOR_FOR_EMAIL_TYPE);
@@ -238,7 +244,7 @@ export async function getCircuitInputs(
 
     const venmo_amount_idx = (raw_header.length - trimStrByStr(email_subject, "$").length).toString();
     console.log("Indexes into for venmo send email are: ", venmo_amount_idx, venmo_send_id_idx);
-    
+
     circuitInputs = {
       in_padded,
       modulus,
@@ -253,6 +259,8 @@ export async function getCircuitInputs(
       // address_plus_one,
       body_hash_idx,
       // email_from_idx,
+      order_id,
+      claim_id
     };
   } else if (circuit === CircuitType.EMAIL_TWITTER) {
     const USERNAME_SELECTOR = Buffer.from(STRING_PRESELECTOR_FOR_EMAIL_TYPE);
@@ -326,7 +334,9 @@ export async function generate_inputs(
   raw_email: Buffer | string,
   eth_address: string,
   type: CircuitType = CircuitType.EMAIL_SUBJECT,
-  nonce_raw: number | null | string = null
+  nonce_raw: number | null | string = null,
+  order_id: string,
+  claim_id: string
 ): Promise<ICircuitInputs> {
   const nonce = typeof nonce_raw == "string" ? nonce_raw.trim() : nonce_raw;
 
@@ -370,7 +380,7 @@ export async function generate_inputs(
   const pubKeyData = pki.publicKeyFromPem(pubkey.toString());
   // const pubKeyData = CryptoJS.parseKey(pubkey.toString(), 'pem');
   let modulus = BigInt(pubKeyData.n.toString());
-  let fin_result = await getCircuitInputs(sig, modulus, message, body, body_hash, eth_address, type);
+  let fin_result = await getCircuitInputs(sig, modulus, message, body, body_hash, order_id, claim_id, eth_address, type);
   return fin_result.circuitInputs;
 }
 
@@ -396,7 +406,7 @@ async function test_generate(writeToFile: boolean = true, email_file_name: strin
   const { email_file, nonce } = await getArgs(email_file_name);
   const email = fs.readFileSync(email_file.trim());
   console.log(email);
-  const gen_inputs = await generate_inputs(email, "0x0000000000000000000000000000000000000000", type, nonce);
+  const gen_inputs = await generate_inputs(email, "0x0000000000000000000000000000000000000000", type, nonce, "1", "0");
   console.log(JSON.stringify(gen_inputs));
   if (writeToFile) {
     const file_dir = email_file.substring(0, email_file.lastIndexOf("/") + 1);


### PR DESCRIPTION
Optimization: Reduce key size to 1024

Before
```
non-linear constraints: 5504292
public inputs: 18
public outputs: 8
private inputs: 7478
```
After
```
non-linear constraints: 5431738
public inputs: 10
public outputs: 8
private inputs: 7470
```
2. Add nullifiers to both circuits
3. Add `order_id` and `claim_id` to both circuits

TODO: Update ^ with constraints after hashing